### PR TITLE
Improve git dir detection

### DIFF
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -22,15 +22,20 @@ chpwd_update_git_vars() {
 
 update_current_git_vars() {
     unset __CURRENT_GIT_STATUS
+    local __GIT_CMD
+    local __GIT_STATUS_RAW
+
+    if ! __GIT_STATUS_RAW=$(git status --porcelain --branch 2>/dev/null); then
+        return
+    fi
 
     if [ "$GIT_PROMPT_EXECUTABLE" = "python" ]; then
         local py_bin=${ZSH_GIT_PROMPT_PYBIN:-"python"}
-        __GIT_CMD=$(git status --porcelain --branch &> /dev/null 2>&1 | ZSH_THEME_GIT_PROMPT_HASH_PREFIX=$ZSH_THEME_GIT_PROMPT_HASH_PREFIX $py_bin "$__GIT_PROMPT_DIR/gitstatus.py")
+        __GIT_CMD=$(ZSH_THEME_GIT_PROMPT_HASH_PREFIX=$ZSH_THEME_GIT_PROMPT_HASH_PREFIX $py_bin "$__GIT_PROMPT_DIR/gitstatus.py" <<< "$__GIT_STATUS_RAW")
     else
-        __GIT_CMD=$(git status --porcelain --branch &> /dev/null | $__GIT_PROMPT_DIR/src/.bin/gitstatus)
+        __GIT_CMD=$($__GIT_PROMPT_DIR/src/.bin/gitstatus <<< "$__GIT_STATUS_RAW")
     fi
     __CURRENT_GIT_STATUS=("${(@s: :)__GIT_CMD}")
-    unset __GIT_CMD
 
     GIT_BRANCH=$__CURRENT_GIT_STATUS[1]
     GIT_AHEAD=$__CURRENT_GIT_STATUS[2]


### PR DESCRIPTION
Before this change, when `cd`ing into a .git directory, you would see
the following on every prompt:

    git_super_status:[:18: integer expression expected: work
    git_super_status:[:28: integer expression expected: operation
    git_super_status:[:28: integer expression expected: this
    git_super_status:[:31: integer expression expected: operation
    git_super_status:[:34: integer expression expected: this
    git_super_status:[:40: integer expression expected: must
    git_super_status:[:44: integer expression expected: be
    git_super_status:[:48: integer expression expected: run
    git_super_status:[:52: integer expression expected: in
    git_super_status:[:56: integer expression expected: a

After this change, the python script is only run iff git status returns
zero, and stderr is discarded.

This also has the nice side-effect of speeding up prompts while `cd`ing
between dirs that are not in a git repo.