### PR TITLE
Handle slashes in branch name when shortening remote

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/shunit2"]
+	path = test/shunit2
+	url = https://github.com/kward/shunit2.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ script:
     else
       stack $ARGS --no-terminal --install-ghc test --haddock;
     fi
+  - ./test/test_gitstatus.zsh
 
 # Caching so the next build will be fast too.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
   apt:
     packages:
       - libgmp-dev
+      - zsh
 
 # Download and unpack the stack executable for haskell, else pip deps.
 install:

--- a/gitstatus.py
+++ b/gitstatus.py
@@ -205,8 +205,8 @@ def current_git_status(lines):
     merge = int(os.path.isfile(merge_file))
     rebase = rebase_progress(rebase_dir)
 
-    values = [str(x) for x in (branch,) + remote + stats +
-              (stashes, local, upstream, merge, rebase)]
+    values = [str(x) for x in (branch,) + remote + stats
+              + (stashes, local, upstream, merge, rebase)]
 
     return ' '.join(values)
 

--- a/test/test_gitstatus.zsh
+++ b/test/test_gitstatus.zsh
@@ -1,0 +1,114 @@
+#!/bin/zsh -y
+
+. ./zshrc.sh
+
+test_show_upstream_unset() {
+  unset ZSH_GIT_PROMPT_SHOW_UPSTREAM
+  GIT_BRANCH=master
+  GIT_UPSTREAM=origin/master
+
+  assertGitPromptEquals '[00m[[01;35mmaster[00m|[01;32m✔[00m][00m'
+}
+
+test_show_upstream_0() {
+  ZSH_GIT_PROMPT_SHOW_UPSTREAM=0
+  GIT_BRANCH=master
+  GIT_UPSTREAM=origin/master
+
+  assertGitPromptEquals '[00m[[01;35mmaster[00m|[01;32m✔[00m][00m'
+}
+
+test_show_upstream_1() {
+  ZSH_GIT_PROMPT_SHOW_UPSTREAM=1
+  GIT_BRANCH=master
+  GIT_UPSTREAM=origin/master
+
+  assertGitPromptEquals '[00m[[01;35mmaster[00m {[34morigin/master[00m}[00m|[01;32m✔[00m][00m'
+}
+
+test_show_upstream_2() {
+  ZSH_GIT_PROMPT_SHOW_UPSTREAM=2
+  GIT_BRANCH=master
+  GIT_UPSTREAM=origin/master
+
+  assertGitPromptEquals '[00m[[01;35mmaster[00m {[34morigin[00m}[00m|[01;32m✔[00m][00m'
+}
+
+test_show_upstream_2_mismatched_upstream() {
+  ZSH_GIT_PROMPT_SHOW_UPSTREAM=2
+  GIT_BRANCH=foo
+  GIT_UPSTREAM=origin/bar
+
+  assertGitPromptEquals '[00m[[01;35mfoo[00m {[34morigin/bar[00m}[00m|[01;32m✔[00m][00m'
+}
+
+test_show_upstream_2_slashy_branch_name() {
+  ZSH_GIT_PROMPT_SHOW_UPSTREAM=2
+  GIT_BRANCH=feature/foo
+  GIT_UPSTREAM=origin/feature/foo
+
+  assertGitPromptEquals '[00m[[01;35mfeature/foo[00m {[34morigin[00m}[00m|[01;32m✔[00m][00m'
+}
+
+test_show_upstream_2_slashy_branch_name_mismatched_upstream() {
+  ZSH_GIT_PROMPT_SHOW_UPSTREAM=2
+  GIT_BRANCH=feature/foo
+  GIT_UPSTREAM=origin/feature/bar
+
+  assertGitPromptEquals '[00m[[01;35mfeature/foo[00m {[34morigin/feature/bar[00m}[00m|[01;32m✔[00m][00m'
+}
+
+test_show_upstream_2_slashy_branch_name_suffix_of_upstream() {
+  # Since we're using suffix removal to shorten a branch name down to an upstream name, this test
+  # checks to make sure we actually get all the way down to a remote, rather than a remote plus some
+  # prefix of a branch name
+
+  ZSH_GIT_PROMPT_SHOW_UPSTREAM=2
+  GIT_BRANCH=foo
+  GIT_UPSTREAM=origin/feature/foo
+
+  assertGitPromptEquals '[00m[[01;35mfoo[00m {[34morigin/feature/foo[00m}[00m|[01;32m✔[00m][00m'
+}
+
+assertGitPromptEquals() {
+  assertEquals "$@" "$(print -P $(git_super_status))"
+}
+
+setUp() {
+  # set some default "sane" values here so in indiviudal tests so we can just set the ones we care about
+  GIT_BRANCH=master
+  GIT_AHEAD=0
+  GIT_BEHIND=0
+  GIT_STAGED=0
+  GIT_CONFLICTS=0
+  GIT_CHANGED=0
+  GIT_UNTRACKED=0
+  GIT_STASHED=0
+  GIT_LOCAL_ONLY=0
+  GIT_UPSTREAM=origin/master
+  GIT_MERGING=0
+  GIT_REBASE=0
+
+  unset ZSH_GIT_PROMPT_SHOW_UPSTREAM
+}
+
+# mock: avoid running gitstatus.py, and just update __CURRENT_GIT_STATUS to match the various individual status vars
+update_current_git_vars() {
+  __CURRENT_GIT_STATUS=(
+    "$GIT_BRANCH"
+    "$GIT_AHEAD"
+    "$GIT_BEHIND"
+    "$GIT_STAGED"
+    "$GIT_CONFLICTS"
+    "$GIT_CHANGED"
+    "$GIT_UNTRACKED"
+    "$GIT_STASHED"
+    "$GIT_LOCAL_ONLY"
+    "$GIT_UPSTREAM"
+    "$GIT_MERGING"
+    "$GIT_REBASE"
+  )
+}
+
+SHUNIT_PARENT="$0"
+. ./test/shunit2/shunit2

--- a/test/test_gitstatus.zsh
+++ b/test/test_gitstatus.zsh
@@ -1,6 +1,8 @@
 #!/bin/zsh -y
 
-. ./zshrc.sh
+# NOTE: this currently expects to be run from the root of the repo
+
+source zshrc.sh
 
 test_show_upstream_unset() {
   unset ZSH_GIT_PROMPT_SHOW_UPSTREAM
@@ -111,4 +113,4 @@ update_current_git_vars() {
 }
 
 SHUNIT_PARENT="$0"
-. ./test/shunit2/shunit2
+source test/shunit2/shunit2

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps = pylint
 [flake8]
 exclude = .tox,*.egg*,build,docs,dist,venv,z_scratch
 ; Ignore some warnings, comma list
-ignore = F403
+ignore = F403,W503
 max-complexity = 10
 max-line-length = 100
 statistics = 1

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -62,9 +62,9 @@ git_super_status() {
         if [ "$GIT_LOCAL_ONLY" -ne "0" ]; then
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_LOCAL%{${reset_color}%}"
         elif [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -gt "0" ] && [ -n "$GIT_UPSTREAM" ] && [ "$GIT_UPSTREAM" != ".." ]; then
-            local parts=( "${(s:/:)GIT_UPSTREAM}" )
-            if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] && [ "$parts[2]" = "$GIT_BRANCH" ]; then
-                GIT_UPSTREAM="$parts[1]"
+            local git_short_upstream=${GIT_UPSTREAM%%"/$GIT_BRANCH"}
+            if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] ; then
+              GIT_UPSTREAM=$git_short_upstream
             fi
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UPSTREAM_FRONT$GIT_UPSTREAM$ZSH_THEME_GIT_PROMPT_UPSTREAM_END%{${reset_color}%}"
         fi

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -64,7 +64,9 @@ git_super_status() {
         elif [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -gt "0" ] && [ -n "$GIT_UPSTREAM" ] && [ "$GIT_UPSTREAM" != ".." ]; then
             if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] ; then
               local git_short_upstream="${GIT_UPSTREAM%%"/$GIT_BRANCH"}"
-              local short_parts=( "${(s:/:)git_short_upstream}" )
+              local short_parts  # some versions of zsh (e.g. 5.0.2) can't handle array assignment on the same line as `local`
+              short_parts=( "${(s:/:)git_short_upstream}" )
+
               if [ "$#short_parts" -eq '1' ] ;  then
                 GIT_UPSTREAM="$git_short_upstream"
               fi

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -63,7 +63,8 @@ git_super_status() {
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_LOCAL%{${reset_color}%}"
         elif [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -gt "0" ] && [ -n "$GIT_UPSTREAM" ] && [ "$GIT_UPSTREAM" != ".." ]; then
             local git_short_upstream=${GIT_UPSTREAM%%"/$GIT_BRANCH"}
-            if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] ; then
+            local short_parts=(${(s:/:)git_short_upstream})
+            if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] && [ $#short_parts -eq '1' ] ; then
               GIT_UPSTREAM=$git_short_upstream
             fi
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UPSTREAM_FRONT$GIT_UPSTREAM$ZSH_THEME_GIT_PROMPT_UPSTREAM_END%{${reset_color}%}"

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -62,10 +62,12 @@ git_super_status() {
         if [ "$GIT_LOCAL_ONLY" -ne "0" ]; then
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_LOCAL%{${reset_color}%}"
         elif [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -gt "0" ] && [ -n "$GIT_UPSTREAM" ] && [ "$GIT_UPSTREAM" != ".." ]; then
-            local git_short_upstream=${GIT_UPSTREAM%%"/$GIT_BRANCH"}
-            local short_parts=(${(s:/:)git_short_upstream})
-            if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] && [ $#short_parts -eq '1' ] ; then
-              GIT_UPSTREAM=$git_short_upstream
+            if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] ; then
+              local git_short_upstream=${GIT_UPSTREAM%%"/$GIT_BRANCH"}
+              local short_parts=(${(s:/:)git_short_upstream})
+              if [ $#short_parts -eq '1' ] ;  then
+                GIT_UPSTREAM=$git_short_upstream
+              fi
             fi
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UPSTREAM_FRONT$GIT_UPSTREAM$ZSH_THEME_GIT_PROMPT_UPSTREAM_END%{${reset_color}%}"
         fi

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -63,13 +63,13 @@ git_super_status() {
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_LOCAL%{${reset_color}%}"
         elif [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -gt "0" ] && [ -n "$GIT_UPSTREAM" ] && [ "$GIT_UPSTREAM" != ".." ]; then
             if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] ; then
-              local git_short_upstream="${GIT_UPSTREAM%%"/$GIT_BRANCH"}"
-              local git_short_upstream_parts  # some versions of zsh (e.g. 5.0.2) can't handle array assignment on the same line as `local`
-              git_short_upstream_parts=( "${(s:/:)git_short_upstream}" )
+                local git_short_upstream="${GIT_UPSTREAM%%"/$GIT_BRANCH"}"
+                local git_short_upstream_parts  # some versions of zsh (e.g. 5.0.2) can't handle array assignment on the same line as `local`
+                git_short_upstream_parts=( "${(s:/:)git_short_upstream}" )
 
-              if [ "$#git_short_upstream_parts" -eq '1' ] ;  then
-                GIT_UPSTREAM="$git_short_upstream"
-              fi
+                if [ "$#git_short_upstream_parts" -eq '1' ] ;  then
+                    GIT_UPSTREAM="$git_short_upstream"
+                fi
             fi
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UPSTREAM_FRONT$GIT_UPSTREAM$ZSH_THEME_GIT_PROMPT_UPSTREAM_END%{${reset_color}%}"
         fi

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -64,10 +64,10 @@ git_super_status() {
         elif [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -gt "0" ] && [ -n "$GIT_UPSTREAM" ] && [ "$GIT_UPSTREAM" != ".." ]; then
             if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] ; then
               local git_short_upstream="${GIT_UPSTREAM%%"/$GIT_BRANCH"}"
-              local short_parts  # some versions of zsh (e.g. 5.0.2) can't handle array assignment on the same line as `local`
-              short_parts=( "${(s:/:)git_short_upstream}" )
+              local git_short_upstream_parts  # some versions of zsh (e.g. 5.0.2) can't handle array assignment on the same line as `local`
+              git_short_upstream_parts=( "${(s:/:)git_short_upstream}" )
 
-              if [ "$#short_parts" -eq '1' ] ;  then
+              if [ "$#git_short_upstream_parts" -eq '1' ] ;  then
                 GIT_UPSTREAM="$git_short_upstream"
               fi
             fi

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -63,10 +63,10 @@ git_super_status() {
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_LOCAL%{${reset_color}%}"
         elif [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -gt "0" ] && [ -n "$GIT_UPSTREAM" ] && [ "$GIT_UPSTREAM" != ".." ]; then
             if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] ; then
-              local git_short_upstream=${GIT_UPSTREAM%%"/$GIT_BRANCH"}
-              local short_parts=(${(s:/:)git_short_upstream})
-              if [ $#short_parts -eq '1' ] ;  then
-                GIT_UPSTREAM=$git_short_upstream
+              local git_short_upstream="${GIT_UPSTREAM%%"/$GIT_BRANCH"}"
+              local short_parts=( "${(s:/:)git_short_upstream}" )
+              if [ "$#short_parts" -eq '1' ] ;  then
+                GIT_UPSTREAM="$git_short_upstream"
               fi
             fi
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UPSTREAM_FRONT$GIT_UPSTREAM$ZSH_THEME_GIT_PROMPT_UPSTREAM_END%{${reset_color}%}"


### PR DESCRIPTION
## PR Main Content

**Bugfix:** When the branch name contains slashes, setting `ZSH_GIT_PROMPT_SHOW_UPSTREAM=2` did not produce the expected behavior of upstream name getting shortened.

For example, with my current branch name of `fix/handle-slashes-in-branch-name`, and an upstream of `origin/fix/handle-slashes-in-branch-name`, I'd expect a prompt like
```
[fix/handle-slashes-in-branch-name {origin}|✔]
```
but I was actually seeing
```
[fix/handle-slashes-in-branch-name {origin/fix/handle-slashes-in-branch-name}|✔]
```

**Root cause:** original shortening process split on slashes and tried to match last component to branch name. Due to splitting on slashes, last component would be a suffix of branch name, and would not match.

**Fix:** Use suffix removal instead of splitting on slashes.

## Extra Bits

I've also added tests for the shell code, and made a minor fix to make `flake8` pass. These are not technically part of the above, so I can pull these into separate PRs if you prefer.

### Tests

I've brought in [shunit2](https://github.com/kward/shunit2) to test the zsh parts.

In the individual tests, I've written expectations using the fully-rendered version of the prompt, complete with ANSI sequences. This renders nicely if you `cat` or `less -R` the file, but as far as I know all text editors will render the ANSI control chars as garbage.

I decided to include the ANSI garbage because `git_super_status` already outputs ANSI codes even before prompt escapes get interpreted, so to some degree having garbagy expect strings is unavoidable. Going with fully rendered strings means they at least display nicely in `less -R`

### Flake8 Fix

[Flake8 3.6.0 does not like line breaks anywhere around operators](https://gitlab.com/pycqa/flake8/issues/466). This is causing travis builds to always fail. Since `W504` is the current recommendation. I've disabled `W503`.

## Background

I tend to have slashes in my branch names at work, because we use a convention of prefixing feature branches with `feature/`, and fixes with `hotfix/`.