### PR TITLE
Add check to see if we have a work tree before returning output

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -233,6 +233,9 @@ def main():
     if err.lower().startswith('fatal: not a git repository'):
         return
 
+    if err.lower().startswith('fatal: this operation must be run in a work tree'):
+        return
+
     try:
         sys.stdout.write(current_git_status(lines))
         sys.stdout.flush()


### PR DESCRIPTION
In some bare git repos, or sometimes if entering a repo's `.git` directory, if there is no work tree the Git prompt becomes corrupted:
 
![screenshot from 2019-01-16 14-02-07](https://user-images.githubusercontent.com/866144/51275442-96aa2580-1997-11e9-9b65-8b68f2f3384a.png)

This commit adds a check to `gitstatus.py` to return early if `git status` returns `fatal: this operation must be run in a work tree`.