### PR TITLE
Handle slashes in the branch name for upstream branch folding

### DIFF
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -63,7 +63,7 @@ git_super_status() {
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_LOCAL%{${reset_color}%}"
         elif [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -gt "0" ] && [ -n "$GIT_UPSTREAM" ] && [ "$GIT_UPSTREAM" != ".." ]; then
             local parts=( "${(s:/:)GIT_UPSTREAM}" )
-            if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] && [ "$parts[2]" = "$GIT_BRANCH" ]; then
+            if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] && [ "${(j:/:)parts[@]:1}" = "$GIT_BRANCH" ]; then
                 GIT_UPSTREAM="$parts[1]"
             fi
             STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UPSTREAM_FRONT$GIT_UPSTREAM$ZSH_THEME_GIT_PROMPT_UPSTREAM_END%{${reset_color}%}"


### PR DESCRIPTION
If the branch name includes `/` character(s) the upstream folding fails
as we only compare a sub-part of the branch with the upstream branch
which still has the `/` character(s) in it.

Here we manipulate the `parts` array prior to the compare so that we can
include `/`'s when they did exist in the remote branch name.

`${x[@]:1}` gets all but the first element of the `$x` array
`${(j:/:)x}` joins all elements of `$x` with `/`